### PR TITLE
优化：遇到 WEBPAGE_MEDIA_EMPTY 时单张重试

### DIFF
--- a/awsl_pic_pipeline/storage.py
+++ b/awsl_pic_pipeline/storage.py
@@ -22,6 +22,7 @@ class TelegramFile(BaseModel):
 BATCH_SIZE: int = 6
 MAX_RETRIES: int = 10
 RETRY_DELAY: float = 5.0
+INDIVIDUAL_RETRY_DELAY: float = 3.0  # Delay between individual image retries
 
 
 def build_telegram_url(file_id: str) -> str:
@@ -76,16 +77,29 @@ def _files_to_blobs(files: List[TelegramFile]) -> Blobs:
     return Blobs(blobs=blobs_dict)
 
 
-def upload_media_group(group: UploadGroup) -> Optional[List[BlobGroup]]:
+class UploadResult(BaseModel):
+    """Result of upload operation with success and failed blob groups."""
+    succeeded: List[BlobGroup]
+    failed: List[BlobGroup]
+
+
+class BatchUploadResult(BaseModel):
+    """Result of batch upload with files and error type."""
+    files: Optional[List[List[TelegramFile]]]
+    is_webpage_media_empty: bool = False
+
+
+def upload_media_group(group: UploadGroup) -> UploadResult:
     """
     Upload photos to Telegram via awsl-telegram-storage service.
-    Automatically splits into batches of 9 if more than 9 URLs.
+    Automatically splits into batches of 6 if more than 6 URLs.
+    On WEBPAGE_MEDIA_EMPTY error, retries each image individually.
 
     Args:
         group: UploadGroup containing blob_groups and caption
 
     Returns:
-        List of BlobGroup with telegram file info, or None on failure
+        UploadResult with succeeded and failed blob groups
     """
     if not settings.awsl_storage_url or not settings.awsl_storage_api_token:
         raise ValueError("awsl_storage_url and awsl_storage_api_token must be configured")
@@ -94,28 +108,53 @@ def upload_media_group(group: UploadGroup) -> Optional[List[BlobGroup]]:
         raise ValueError("At least 1 BlobGroup required")
 
     urls: List[str] = [list(bg.blobs.blobs.values())[0].url for bg in group.blob_groups]
-    all_files: List[List[TelegramFile]] = []
+    all_files: List[Optional[List[TelegramFile]]] = []
     batches: List[List[str]] = [urls[i:i + BATCH_SIZE] for i in range(0, len(urls), BATCH_SIZE)]
 
     for batch_urls in batches:
-        files: Optional[List[List[TelegramFile]]] = _upload_batch(batch_urls, group.caption)
-        if files is None:
-            return None
-        all_files.extend(files)
+        batch_result: BatchUploadResult = _upload_batch(batch_urls, group.caption)
 
-    result: List[BlobGroup] = []
+        if batch_result.files is not None:
+            # Batch upload succeeded
+            all_files.extend(batch_result.files)
+        elif batch_result.is_webpage_media_empty:
+            # WEBPAGE_MEDIA_EMPTY detected, retry each image individually
+            _logger.info("WEBPAGE_MEDIA_EMPTY detected, retrying batch of %d images individually", len(batch_urls))
+            for i, url in enumerate(batch_urls):
+                single_result: BatchUploadResult = _upload_batch([url], group.caption)
+                if single_result.files and len(single_result.files) > 0:
+                    all_files.append(single_result.files[0])
+                    _logger.info("Successfully uploaded image %d/%d", i + 1, len(batch_urls))
+                else:
+                    all_files.append(None)
+                    _logger.warning("Failed to upload image %d/%d: %s", i + 1, len(batch_urls), url)
+                if i < len(batch_urls) - 1:  # Don't delay after last image
+                    time.sleep(INDIVIDUAL_RETRY_DELAY)
+        else:
+            # Other error, mark all as failed
+            _logger.error("Batch upload failed with non-WEBPAGE_MEDIA_EMPTY error, marking all as failed")
+            all_files.extend([None] * len(batch_urls))
+
+    succeeded: List[BlobGroup] = []
+    failed: List[BlobGroup] = []
+
     for blob_group, files in zip(group.blob_groups, all_files):
-        result.append(BlobGroup(
-            id=blob_group.id,
-            awsl_id=blob_group.awsl_id,
-            blobs=_files_to_blobs(files),
-        ))
+        if files:
+            succeeded.append(BlobGroup(
+                id=blob_group.id,
+                awsl_id=blob_group.awsl_id,
+                blobs=_files_to_blobs(files),
+            ))
+        else:
+            failed.append(blob_group)
+            _logger.warning("Failed blob_group: pic_id=%s", blob_group.id)
 
-    return result
+    _logger.info("Upload result: %d succeeded, %d failed", len(succeeded), len(failed))
+    return UploadResult(succeeded=succeeded, failed=failed)
 
 
-def _upload_batch(urls: List[str], caption: Optional[str] = None) -> Optional[List[List[TelegramFile]]]:
-    """Upload a single batch of URLs (max 9) with retry."""
+def _upload_batch(urls: List[str], caption: Optional[str] = None) -> BatchUploadResult:
+    """Upload a single batch of URLs (max 6) with retry."""
     api_url: str = f"{settings.awsl_storage_url.rstrip('/')}/api/upload/group"
 
     payload: dict = {"urls": urls}
@@ -128,6 +167,8 @@ def _upload_batch(urls: List[str], caption: Optional[str] = None) -> Optional[Li
     }
 
     last_error: Optional[str] = None
+    is_webpage_media_empty: bool = False
+
     for attempt in range(MAX_RETRIES):
         try:
             response: httpx.Response = _client.post(api_url, json=payload, headers=headers)
@@ -136,8 +177,9 @@ def _upload_batch(urls: List[str], caption: Optional[str] = None) -> Optional[Li
             if not data.get("success"):
                 last_error = data.get("error", "Unknown error")
                 if "WEBPAGE_MEDIA_EMPTY" in last_error:
-                    _logger.warning("WEBPAGE_MEDIA_EMPTY detected, skipping: %s", last_error)
-                    return None
+                    _logger.warning("WEBPAGE_MEDIA_EMPTY detected: %s", last_error)
+                    is_webpage_media_empty = True
+                    return BatchUploadResult(files=None, is_webpage_media_empty=True)
                 _logger.warning("Upload failed (attempt %d/%d): %s", attempt + 1, MAX_RETRIES, last_error)
                 time.sleep(RETRY_DELAY * (attempt + 1))
                 continue
@@ -149,7 +191,7 @@ def _upload_batch(urls: List[str], caption: Optional[str] = None) -> Optional[Li
             ]
 
             _logger.info("Uploaded %d images to Telegram", len(files))
-            return files
+            return BatchUploadResult(files=files, is_webpage_media_empty=False)
 
         except httpx.HTTPError as e:
             last_error = str(e)
@@ -161,4 +203,4 @@ def _upload_batch(urls: List[str], caption: Optional[str] = None) -> Optional[Li
             time.sleep(RETRY_DELAY * (attempt + 1))
 
     _logger.error("Upload failed after %d attempts: %s", MAX_RETRIES, last_error)
-    return None
+    return BatchUploadResult(files=None, is_webpage_media_empty=is_webpage_media_empty)


### PR DESCRIPTION
## 概述
- 添加 BatchUploadResult 来区分 WEBPAGE_MEDIA_EMPTY 和其他错误
- 默认批量上传（每批 6 张图片）
- 遇到 WEBPAGE_MEDIA_EMPTY 时，单张重试每张图片（延迟 3 秒）
- 跳过并软删除单张重试失败的图片
- 分别保存成功的上传和删除失败的图片
- 添加进度日志（第 N/总数 组）
- 处理部分成功：保存成功的图片，删除失败的图片

## 主要改动
- **storage.py**: 添加 UploadResult 和 BatchUploadResult 模型
- **storage.py**: 实现 WEBPAGE_MEDIA_EMPTY 错误时的单张重试逻辑
- **storage.py**: 添加 INDIVIDUAL_RETRY_DELAY 常量（3 秒）
- **migration.py**: 处理部分上传成功/失败
- **migration.py**: 添加进度日志（组 N/总数）

## 测试计划
- [x] 批量上传 6 张图片全部成功
- [x] 第 1 张图片触发 WEBPAGE_MEDIA_EMPTY
- [x] 所有图片 WEBPAGE_MEDIA_EMPTY 失败
- [x] 非 WEBPAGE_MEDIA_EMPTY 错误处理
- [x] 验证 3 秒延迟不会触发限流
- [x] 检查部分成功后的数据库一致性

## 行为变化
**之前**: 批量上传遇到 WEBPAGE_MEDIA_EMPTY 后，整个组失败并删除所有图片

**现在**: 
1. 默认批量上传（6 张/批）
2. 遇到 WEBPAGE_MEDIA_EMPTY → 单张重试
3. 单张重试失败 → 仅删除该图片
4. 部分成功 → 保存成功的，删除失败的

🤖 Generated with [Claude Code](https://claude.com/claude-code)