### PR TITLE
修复：文档上传使用 form-data 而非 JSON

### DIFF
--- a/awsl_pic_pipeline/storage.py
+++ b/awsl_pic_pipeline/storage.py
@@ -164,19 +164,19 @@ def _upload_as_document(url: str) -> Optional[List[TelegramFile]]:
     """Upload single image as document (fallback when photo upload fails). Only retry on 429."""
     api_url: str = f"{settings.awsl_storage_url.rstrip('/')}/api/upload"
 
-    payload: dict = {
+    # Use form data instead of JSON
+    form_data: dict = {
         "url": url,
         "media_type": "document"
     }
 
     headers: dict[str, str] = {
         "X-Api-Token": settings.awsl_storage_api_token,
-        "Content-Type": "application/json",
     }
 
     for attempt in range(MAX_RETRIES):
         try:
-            response: httpx.Response = _client.post(api_url, json=payload, headers=headers)
+            response: httpx.Response = _client.post(api_url, data=form_data, headers=headers)
             data: dict = response.json()
 
             if not data.get("success"):


### PR DESCRIPTION
## 问题
PR #16 合并后，文档上传 fallback 失败，错误信息：
```
Document upload failed (non-retriable): No file or URL provided
```

## 原因
`/api/upload` 端点期望 `multipart/form-data` 格式，但代码发送的是 JSON。

## 修复
- ✅ 从 `json=payload` 改为 `data=form_data`
- ✅ 移除 `Content-Type: application/json` header
- ✅ 让 httpx 自动处理 `multipart/form-data`
- ✅ 修复 "No file or URL provided" 错误

## 测试
- [x] 文档上传成功接收 URL 参数
- [x] 正确返回 file_id

## 依赖
- 基于 #16 的修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)